### PR TITLE
Dev/0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BACAP_Parser"
-version = "0.5"
+version = "0.5.0"
 description = "Library to parse BlazeAndCavesAdvancementsPack and Addons for it"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BACAP_Parser"
-version = "0.4.3"
+version = "0.5"
 description = "Library to parse BlazeAndCavesAdvancementsPack and Addons for it"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/BACAP_Parser/AdvType.py
+++ b/src/BACAP_Parser/AdvType.py
@@ -127,7 +127,7 @@ class AdvTypeManager:
         :param color: The color to match against ``adv_type.colors``. If None, this parameter is ignored.
         :param tab: The tab identifier to match against ``adv_type.tabs``. If None, this parameter is ignored.
         :return: The matched `AdvType` instance.
-        :raises MultipleTypesMatch: If more than one ``AdvType`` matches the given parameters.
+        :raises MultipleTypesMatch: If more than one ``AdvType`` matches the given parameters without clear priority.
         :raises NoTypesMatch: If no ``AdvType`` matches the given parameters.
         """
         matching_types = [
@@ -138,8 +138,18 @@ class AdvTypeManager:
         ]
 
         if len(matching_types) > 1:
-            raise MultipleTypesMatch(frame, color, tab)
-        elif len(matching_types) == 1:
+            # Prioritize types with a non-None "tabs" that matches the provided "tab".
+            prioritized_types = [
+                adv_type for adv_type in matching_types
+                if adv_type.tabs is not None and tab in adv_type.tabs
+            ]
+
+            if len(prioritized_types) == 1:
+                return prioritized_types[0]
+            elif len(prioritized_types) > 1:
+                raise MultipleTypesMatch(frame, color, tab)
+
+        if len(matching_types) == 1:
             return matching_types[0]
-        else:
-            raise NoTypesMatch(frame, color, tab)
+
+        raise NoTypesMatch(frame, color, tab)


### PR DESCRIPTION
Added prioritization logic for selecting AdvType based on the presence of tabs

- Updated the logic of the recognize_type method to handle cases where multiple matching AdvType instances exist.
- Now, if several types match the given parameters (frame, color, tab), preference is given to types whose tabs field is not None and contains the provided tab parameter.
- If multiple matching types have tabs, the MultipleTypesMatch exception is raised.
- If no types with a suitable tabs field are found, the standard selection logic is used.

Reason for changes:

Previously, the method did not consider the presence of tabs as an important criterion for prioritizing among multiple matching AdvType instances.